### PR TITLE
implement check-in flow :)

### DIFF
--- a/__tests__/checkIn.test.ts
+++ b/__tests__/checkIn.test.ts
@@ -1,0 +1,46 @@
+import { checkIn } from "../utils/checkIn";
+
+describe('testing the util function for checking in on past pairings', () =>{
+    const mockApp: any = {
+        client: {
+            conversations: {
+
+            },
+            chat: {
+
+            }
+        }
+    };
+    it('should send a good status message if non-bot messages exceed 0', async () => {
+        const messageHistory = [{user: "Vera"}, {user: "Ryan"}];
+        const mockConversations: any = {
+            history: jest.fn().mockReturnValue({ messages: messageHistory }),
+        };
+        const mockChat: any = {
+            postMessage: jest.fn().mockReturnValue({})
+        };
+        mockApp.client.conversations = mockConversations;
+        mockApp.client.chat = mockChat;
+
+        await checkIn(mockApp);
+
+        expect(mockConversations.history).toHaveBeenCalled();
+        expect(mockChat.postMessage).toHaveBeenCalledWith({channel: "test_channel", text: 'Thank you for talking to each other!!!'});
+    })
+    it('should send a bad status message if no non-bot messages were sent', async () => {
+        const emptyHistory: string[] = [];
+        const mockConversations: any = {
+            history: jest.fn().mockReturnValue({ messages: emptyHistory }),
+        };
+        const mockChat: any = {
+            postMessage: jest.fn().mockReturnValue({})
+        };
+        mockApp.client.conversations = mockConversations;
+        mockApp.client.chat = mockChat;
+
+        await checkIn(mockApp);
+
+        expect(mockConversations.history).toHaveBeenCalled();
+        expect(mockChat.postMessage).toHaveBeenCalledWith({channel: "test_channel", text: "SAY SOMETHING NOW <@Jia>!!"});
+    })
+})

--- a/__tests__/testPairings.json
+++ b/__tests__/testPairings.json
@@ -1,0 +1,1 @@
+[["test_channel",["Jia"]]]

--- a/package-lock.json
+++ b/package-lock.json
@@ -3437,11 +3437,18 @@
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true
     },
+    "cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "requires": {
+        "cross-spawn": "^7.0.1"
+      }
+    },
     "cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
       "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
-      "dev": true,
       "requires": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -4328,8 +4335,7 @@
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-      "dev": true
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
     },
     "istanbul-lib-coverage": {
       "version": "3.2.0",
@@ -5408,8 +5414,7 @@
     "path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
     },
     "path-parse": {
       "version": "1.0.7",
@@ -5771,7 +5776,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "requires": {
         "shebang-regex": "^3.0.0"
       }
@@ -5779,8 +5783,7 @@
     "shebang-regex": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
     },
     "side-channel": {
       "version": "1.0.4",
@@ -6217,7 +6220,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "requires": {
         "isexe": "^2.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "jest",
+    "test": "cross-env PAIRINGS_PATH=./__tests__/testPairings.json jest",
     "build": "tsc"
   },
   "repository": {
@@ -23,6 +23,7 @@
     "@babel/preset-typescript": "^7.16.0",
     "@slack/bolt": "^3.8.1",
     "babel-jest": "^27.3.1",
+    "cross-env": "^7.0.3",
     "dotenv": "^10.0.0"
   },
   "devDependencies": {

--- a/utils/checkIn.ts
+++ b/utils/checkIn.ts
@@ -5,6 +5,12 @@ import { BOT_USER_ID } from "./generatePairs";
 
 require('dotenv').config();
 
+/**
+ * Checks the conversation history for each pairing to determine if introductions were 
+ * made. If no non-bot messages were sent, randomly ping channel user prompting them to send a 
+ * message.
+ * @param app 
+ */
 export const checkIn = async (app: App) => {
     // TODO: set this env variable before deploy
     const pairingsPath = <string>process.env.PAIRINGS_PATH;

--- a/utils/checkIn.ts
+++ b/utils/checkIn.ts
@@ -1,0 +1,37 @@
+import { App } from "@slack/bolt";
+import { ChatPostMessageResponse, ConversationsHistoryResponse } from "@slack/web-api";
+import fs from 'fs';
+import { BOT_USER_ID } from "./generatePairs";
+
+require('dotenv').config();
+
+export const checkIn = async (app: App) => {
+    // TODO: set this env variable before deploy
+    const pairingsPath = <string>process.env.PAIRINGS_PATH;
+    let pairsJson = fs.readFileSync(pairingsPath, {encoding: 'utf8'});
+    let channelAndPairs: Map<string, string[]> = new Map(JSON.parse(pairsJson));
+
+    for (const [channelId, pair] of channelAndPairs.entries()) {
+        const historyResponse: ConversationsHistoryResponse = await app.client.conversations.history({channel: channelId});
+        if(!historyResponse.ok) {
+            console.log(`Conversation history could not be opened. Error: ${historyResponse.error}`)
+        }
+     
+        if (historyResponse.messages) {
+            const userMessages = historyResponse.messages.filter(message => message.user !== BOT_USER_ID);
+            if (userMessages.length > 0) {
+                const goodJobMessageResponse: ChatPostMessageResponse = await app.client.chat.postMessage({channel: channelId, text: 'Thank you for talking to each other!!!'});
+                if(!goodJobMessageResponse.ok) {
+                    console.log(`Message could not be posted. Error: ${goodJobMessageResponse.error}`)
+                }
+            }
+            else {
+                const userToPing = pair[Math.floor(Math.random() * channelAndPairs.size)];
+                const pleaseTalkMessageResponse: ChatPostMessageResponse = await app.client.chat.postMessage({channel: channelId, text: `SAY SOMETHING NOW <@${userToPing}>!!`});
+                if(!pleaseTalkMessageResponse.ok) {
+                    console.log(`Message could not be posted. Error: ${pleaseTalkMessageResponse.error}`)
+                }
+            }
+        }
+    }
+}

--- a/utils/generatePairs.ts
+++ b/utils/generatePairs.ts
@@ -2,7 +2,7 @@ import { App } from "@slack/bolt";
 
 //TODO: change this to actual channel id when deploying
 const TESTING_CHANNEL_ID = "C02J6R0SUSX";
-const BOT_USER_ID = "U02J904RH1S";
+export const BOT_USER_ID = "U02J904RH1S";
 
 const generatePairs = async (app: App) => {
     const membersResponse = await app.client.conversations.members({channel: TESTING_CHANNEL_ID})

--- a/utils/pairings.json
+++ b/utils/pairings.json
@@ -1,0 +1,1 @@
+[["hahaha",["jia","sophie","ryan"]]]

--- a/utils/startConversations.ts
+++ b/utils/startConversations.ts
@@ -1,6 +1,7 @@
 import { App } from "@slack/bolt";
 import { ChatPostMessageResponse, ConversationsOpenResponse } from '@slack/web-api';
 import generatePairs from "./generatePairs";
+import fs from 'fs';
 
 const INTRO_MSG = "Say hi to your boba buddy!"
 const ICEBREAKER_1 = "What's your hot take?"
@@ -16,7 +17,10 @@ const ICEBREAKER_10 = "What hobbies do you have (outside of Sandbox)?"
 const ICEBREAKERS = [ICEBREAKER_1, ICEBREAKER_2, ICEBREAKER_3, ICEBREAKER_4, ICEBREAKER_5, ICEBREAKER_6, ICEBREAKER_7, ICEBREAKER_8, ICEBREAKER_9, ICEBREAKER_10]
 
 export const startConversations = async (app: App) => {
+
     const pairs = await generatePairs(app);
+    const channelAndPairs = new Map<string, string[]>();
+
     // iterate through all pairs to open a DM and send an intro message
     for (const pair of pairs) {
       // generate users string
@@ -42,6 +46,11 @@ export const startConversations = async (app: App) => {
         if (!icebreakerResponse.ok) {
           console.log(`Icebreaker could not be sent. Error: ${icebreakerResponse.error}`);
         }
+
+        channelAndPairs.set(conversationId, pair);
       }
+      
     }
+    var storedPairs = JSON.stringify(Array.from(channelAndPairs.entries()));
+    fs.writeFileSync('./utils/pairings.json', storedPairs);
   }


### PR DESCRIPTION
run `npm test` to test!

Issue: #5

Implemented the check-in flow for previous pairings in the `pairings.json`  file after `pairAndIntroduce` is called.

Flow of how check-in works:
- Grabs the list of channels and pairings from the current pairing cycle 
- For each channel:
    - if any member in the pairings have sent a message, then send a congrats message :D
    - if no one has said anything, aggressively ping someone to start a conversation >:D
 
Also added tests for this check-in stuff, but because we made tests, we added a environment variable for the path to the pairings json file. Basically, we just gotta remember to set this environment variable pre-deploy. ya yeet
